### PR TITLE
Sort attribute keys

### DIFF
--- a/lib/HTML/Tag.pm6
+++ b/lib/HTML/Tag.pm6
@@ -12,7 +12,8 @@ class HTML::Tag
     method mktag(:$prefix, :$suffix = '>') {
 	my $tag;
 	$tag = $prefix if $prefix;
-	$.attr.keys.map: { when 'checked'   { $tag ~= ' checked' }
+	$.attr.keys.sort.map: {
+			   when 'checked'   { $tag ~= ' checked'  }
 			   when 'disabled'  { $tag ~= ' disabled' }
 			   when 'readonly'  { $tag ~= ' readonly' }
 			   when 'required'  { $tag ~= ' required' }

--- a/t/0010-html.t
+++ b/t/0010-html.t
@@ -13,13 +13,13 @@ use HTML::Tag::Macro;
 is HTML::Tag::p.new(:text('testing & here')).render, '<p>testing &amp; here</p>', 'HTML::Tag::p works ok';
 is HTML::Tag::p.new(text => 'test', :id('myID')).render, '<p id="myID">test</p>', 'HTML::Tag::p.id works';
 is HTML::Tag::p.new(text => 'test', :class('myclass')).render, '<p class="myclass">test</p>', 'HTML::Tag::p.class works';
-is HTML::Tag::p.new(:text('test'), :class('MYClass'), :id('myNAME')).render, '<p id="myNAME" class="MYClass">test</p>', 'HTML::Tag::p.class and .id both work together';
+is HTML::Tag::p.new(:text('test'), :class('MYClass'), :id('myNAME')).render, '<p class="MYClass" id="myNAME">test</p>', 'HTML::Tag::p.class and .id both work together';
 
 # Anchor
 is HTML::Tag::a.new(:text('My Page'), :href('http://mydomain.com')).render, '<a href="http://mydomain.com">My Page</a>', 'HTML::Tag::a works';
 
 # Link
-is HTML::Tag::link.new(:href('http://mydomain.com'), :rel('stylesheet'), :type('text/css')).render, '<link rel="stylesheet" href="http://mydomain.com" type="text/css">', 'HTML::Tag::link works';
+is HTML::Tag::link.new(:href('http://mydomain.com'), :rel('stylesheet'), :type('text/css')).render, '<link href="http://mydomain.com" rel="stylesheet" type="text/css">', 'HTML::Tag::link works';
 
 # Break
 is HTML::Tag::br.new.render, '<br>', 'HTML::Tag::br works';
@@ -45,7 +45,7 @@ is HTML::Tag::div.new(:text('My Div'), :style('funnyfont')).render, '<div style=
 is HTML::Tag::span.new(:text('My Span')).render, '<span>My Span</span>', 'HTML::Tag::span works';
 
 # Form
-is HTML::Tag::form.new(:action('/myscript/is') :id('myid')).render, '<form method="POST" id="myid" action="/myscript/is"></form>', 'HTML::Tag::form works';
+is HTML::Tag::form.new(:action('/myscript/is') :id('myid')).render, '<form action="/myscript/is" id="myid"method="POST"></form>', 'HTML::Tag::form works';
 is HTML::Tag::input.new(:value('testval'), :min(0)).render, '<input min="0" type="text" value="testval">', 'HTML::Tag::input works';
 is HTML::Tag::input.new(:type('radio'), :checked(True)).render, '<input checked type="radio">', 'HTML::Tag::input radio checked works';
 is HTML::Tag::textarea.new(:text('This is in the box'), :id('boxy')).render, '<textarea id="boxy">This is in the box</textarea>', 'HTML::Tag::textarea works';
@@ -56,13 +56,13 @@ is HTML::Tag::fieldset.new(:form('myform'), :text($legend, $tag)).render, '<fiel
 
 # CSS Macro
 is HTML::Tag::Macro::CSS.new(:href('css/file.css')).render,
-'<link rel="stylesheet" href="css/file.css" type="text/css">', 'HTML::Tag::Macro:CSS works';
+'<link href="css/file.css" rel="stylesheet" type="text/css">', 'HTML::Tag::Macro:CSS works';
 
 # Image
 is HTML::Tag::img.new(:src('/img/foo.jpg'),
 		      :width(100), :height(150),
 		      :alt('funny pic'),
-		      :border(0)).render, '<img height="150" alt="funny pic" border="0" width="100" src="/img/foo.jpg">', 'HTML::Tag::img works.';
+		      :border(0)).render, '<img alt="funny pic" border="0" height="150" src="/img/foo.jpg" width="100">', 'HTML::Tag::img works.';
 
 # Table
 my $th1 = HTML::Tag::th.new(:text('Col1'));

--- a/t/0020-form.t
+++ b/t/0020-form.t
@@ -19,7 +19,7 @@ my @def = ( { username => { }},
 
 $form.def = @def;
 
-is $form.render, '<form method="POST" name="form" action="/"><input name="username" id="form-username" type="text"><input name="password" id="form-password" type="text"><input name="submit" id="form-submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form minimal def';
+is $form.render, '<form action="/" method="POST" name="form"><input id="form-username" name="username" type="text"><input id="form-password" name="password" type="text"><input id="form-submit" name="submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form minimal def';
 
 @def = ( { username => { autofocus => True }},
 	 { password => { }},
@@ -29,11 +29,11 @@ is $form.render, '<form method="POST" name="form" action="/"><input name="userna
 
 $form.def = @def;
 
-is $form.render, '<form method="POST" name="form" action="/"><input name="username" id="form-username" type="text" autofocus><input name="password" id="form-password" type="text"><input name="submit" id="form-submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form autofocus';
+is $form.render, '<form action="/" method="POST" name="form"><input autofocus id="form-username" name="username" type="text"><input id="form-password" name="password" type="text"><input id="form-submit" name="submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form autofocus';
 
 ok $form = HTML::Tag::Macro::Form.new(:def(@def), :action('/')), 'HTML::Tag::Macro::Form def passed directly in';
 
-is $form.render, '<form method="POST" name="form" action="/"><label for="form-username">Username</label><input name="username" id="form-username" type="text" autofocus><label for="form-password">Password</label><input name="password" id="form-password" type="text"><label for="form-submit">Submit</label><input name="submit" id="form-submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form with labels';
+is $form.render, '<form action="/" method="POST" name="form"><label for="form-username">Username</label><input autofocus id="form-username" name="username" type="text"><label for="form-password">Password</label><input id="form-password" name="password" type="text"><label for="form-submit">Submit</label><input id="form-submit" name="submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form with labels';
 
 @def = ( { username => { }},
 	 { password => { }},
@@ -44,14 +44,14 @@ is $form.render, '<form method="POST" name="form" action="/"><label for="form-us
 
 $form.def = @def;
 
-is $form.render, '<form method="POST" name="form" action="/"><label for="form-username">Username</label><input name="username" id="form-username" type="text"><label for="form-password">Password</label><input name="password" id="form-password" type="text"><input name="submit" id="form-submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form with labels excluding one';
+is $form.render, '<form action="/" method="POST" name="form"><label for="form-username">Username</label><input id="form-username" name="username" type="text"><label for="form-password">Password</label><input id="form-password" name="password" type="text"><input id="form-submit" name="submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form with labels excluding one';
 
 my %input;
 %input<username> = 'mark';
 
 ok $form = HTML::Tag::Macro::Form.new(:nolabel, :input(%input), :def(@def), :action('/')), 'HTML::Tag::Macro::Form input values instatiate';
 
-is $form.render, '<form method="POST" name="form" action="/"><input name="username" id="form-username" type="text" value="mark"><input name="password" id="form-password" type="text"><input name="submit" id="form-submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form with value test';
+is $form.render, '<form action="/" method="POST" name="form"><input id="form-username" name="username" type="text" value="mark"><input id="form-password" name="password" type="text"><input id="form-submit" name="submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form with value test';
 
 @def = ( { username => { }},
 	 { password => { type => 'password' }},
@@ -65,7 +65,7 @@ is $form.render, '<form method="POST" name="form" action="/"><input name="userna
 
 ok $form = HTML::Tag::Macro::Form.new(:input(%input), :def(@def), :action('/')), 'HTML::Tag::Macro::Form input values instatiate for pw test';
 
-is $form.render, '<form method="POST" name="form" action="/"><label for="form-username">Username</label><input name="username" id="form-username" type="text" value="mark"><label for="form-password">Password</label><input name="password" id="form-password" type="password"><input name="submit" id="form-submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form with value test password types set no values';
+is $form.render, '<form action="/" method="POST" name="form"><label for="form-username">Username</label><input id="form-username" name="username" type="text" value="mark"><label for="form-password">Password</label><input id="form-password" name="password" type="password"><input id="form-submit" name="submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form with value test password types set no values';
 
 my $tag-after = HTML::Tag::br.new;
 my $tag-before = HTML::Tag::span.new(:text('oofie'));
@@ -80,7 +80,7 @@ my $tag-before = HTML::Tag::span.new(:text('oofie'));
 
 ok $form = HTML::Tag::Macro::Form.new(:input(%input), :def(@def), :action('/')), 'HTML::Tag::Macro::Form input values instatiate for tags before/after';
 
-is $form.render, '<form method="POST" name="form" action="/"><label for="form-username">Username</label><input name="username" id="form-username" type="text" value="mark"><br><label for="form-password">Password</label><input name="password" id="form-password" type="password"><span>oofie</span><input name="submit" id="form-submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form testing before/after tags';
+is $form.render, '<form action="/" method="POST" name="form"><label for="form-username">Username</label><input id="form-username" name="username" type="text" value="mark"><br><label for="form-password">Password</label><input id="form-password" name="password" type="password"><span>oofie</span><input id="form-submit" name="submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form testing before/after tags';
 
 @def = ( { username => { swallowed-by => $tag-before }},
 	 { password => { type => 'password' }},
@@ -91,7 +91,7 @@ is $form.render, '<form method="POST" name="form" action="/"><label for="form-us
 
 ok $form = HTML::Tag::Macro::Form.new(:input(%input), :def(@def), :action('/')), 'HTML::Tag::Macro::Form input values instatiate for input swallowing';
 
-is $form.render, '<form method="POST" name="form" action="/"><span>oofie<label for="form-username">Username</label><input name="username" id="form-username" type="text" value="mark"></span><label for="form-password">Password</label><input name="password" id="form-password" type="password"><input name="submit" id="form-submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form input swallowing';
+is $form.render, '<form action="/" method="POST" name="form"><span>oofie<label for="form-username">Username</label><input id="form-username" name="username" type="text" value="mark"></span><label for="form-password">Password</label><input id="form-password" name="password" type="password"><input id="form-submit" name="submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form input swallowing';
 
 
 ok $form = HTML::Tag::Macro::Form.new(:nolabel, :action('/')), 'HTML::Tag::Macro::Form for required test instantated';
@@ -104,7 +104,7 @@ ok $form = HTML::Tag::Macro::Form.new(:nolabel, :action('/')), 'HTML::Tag::Macro
 
 $form.def = @def;
 
-is $form.render, '<form method="POST" name="form" action="/"><input name="username" id="form-username" type="text" required><input name="password" id="form-password" type="text"><input name="submit" id="form-submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form required fields';
+is $form.render, '<form action="/" method="POST" name="form"><input id="form-username" name="username" required type="text"><input id="form-password" name="password" type="text"><input id="form-submit" name="submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form required fields';
 
 $form = HTML::Tag::Macro::Form.new(:nolabel, :action('/'));
 
@@ -116,7 +116,7 @@ $form = HTML::Tag::Macro::Form.new(:nolabel, :action('/'));
 
 $form.def = @def;
 
-is $form.render, '<form method="POST" name="form" action="/"><input name="username" id="form-username" class="pink" type="text"><input name="password" id="blue" type="text"><input name="submit" id="form-submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form using individual/normal tag attrs';
+is $form.render, '<form action="/" method="POST" name="form"><input class="pink" id="form-username" name="username" type="text"><input id="blue" name="password" type="text"><input id="form-submit" name="submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form using individual/normal tag attrs';
 
 $form = HTML::Tag::Macro::Form.new(:nolabel, :action('/'));
 
@@ -129,7 +129,7 @@ $form = HTML::Tag::Macro::Form.new(:nolabel, :action('/'));
 
 $form.def = @def;
 
-is $form.render, '<form method="POST" name="form" action="/"><input name="username" id="form-username" type="text"><input name="password" id="form-password" type="text"><textarea name="notes" id="form-notes"></textarea><input name="submit" id="form-submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form empty textarea';
+is $form.render, '<form action="/" method="POST" name="form"><input id="form-username" name="username" type="text"><input id="form-password" name="password" type="text"><textarea id="form-notes" name="notes"></textarea><input id="form-submit" name="submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form empty textarea';
 
 $form = HTML::Tag::Macro::Form.new(:nolabel, :action('/'));
 
@@ -143,7 +143,7 @@ $form = HTML::Tag::Macro::Form.new(:nolabel, :action('/'));
 
 $form.def = @def;
 
-is $form.render, '<form method="POST" name="form" action="/"><input name="username" id="form-username" type="text"><input name="password" id="form-password" type="text"><textarea name="notes" id="form-notes">I am a test</textarea><input name="submit" id="form-submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form textarea with text';
+is $form.render, '<form action="/" method="POST" name="form"><input id="form-username" name="username" type="text"><input id="form-password" name="password" type="text"><textarea id="form-notes" name="notes">I am a test</textarea><input id="form-submit" name="submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form textarea with text';
 
 %input = notes => 'do not forget';
 
@@ -159,7 +159,7 @@ $form = HTML::Tag::Macro::Form.new(:nolabel, :input(%input), :action('/'));
 
 $form.def = @def;
 
-is $form.render, '<form method="POST" name="form" action="/"><input name="username" id="form-username" type="text"><input name="password" id="form-password" type="text"><textarea name="notes" id="form-notes">I am a test</textarea><input name="submit" id="form-submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form textarea with text overrides value';
+is $form.render, '<form action="/" method="POST" name="form"><input id="form-username" name="username" type="text"><input id="form-password" name="password" type="text"><textarea id="form-notes" name="notes">I am a test</textarea><input id="form-submit" name="submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form textarea with text overrides value';
 
 %input = notes => 'do not forget';
 
@@ -174,5 +174,5 @@ $form = HTML::Tag::Macro::Form.new(:nolabel, :input(%input), :action('/'));
 
 $form.def = @def;
 
-is $form.render, '<form method="POST" name="form" action="/"><input name="username" id="form-username" type="text"><input name="password" id="form-password" type="text"><textarea name="notes" id="form-notes">do not forget</textarea><input name="submit" id="form-submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form textarea values work';
+is $form.render, '<form action="/" method="POST" name="form"><input id="form-username" name="username" type="text"><input id="form-password" name="password" type="text"><textarea id="form-notes" name="notes">do not forget</textarea><input id="form-submit" name="submit" type="submit" value="Login"></form>', 'HTML::Tag::Macro::Form textarea values work';
 

--- a/t/0040-table.t
+++ b/t/0040-table.t
@@ -37,7 +37,7 @@ my $td-opts = %(1 => {class => 'pretty'},
 		2 => {class => 'pretty',
 		      id    => 'lastone'});
 $table.row(:td-opts($td-opts), @data);
-is $table.render, '<table><tr><th>Col1</th><th>Col2</th><th>Col3</th></tr><tr><td>11</td><td>22</td><td>33</td></tr><tr><td>111</td><td class="pretty">222</td><td id="lastone" class="pretty">333</td></tr></table>', 'HTML::Tag::Macro::Table works with td-opts';
+is $table.render, '<table><tr><th>Col1</th><th>Col2</th><th>Col3</th></tr><tr><td>11</td><td>22</td><td>33</td></tr><tr><td>111</td><td class="pretty">222</td><td class="pretty" id="lastone">333</td></tr></table>', 'HTML::Tag::Macro::Table works with td-opts';
 
 $table = HTML::Tag::Macro::Table.new(:table-opts(id => 'mytable'));
 @data = 'Col1', 'Col2', 'Col3';


### PR DESCRIPTION
Otherwise hash randomization will cause them to be in different order
every time, which makes tests fail.

Resolves https://github.com/adaptiveoptics/HTML-Tag/issues/3.